### PR TITLE
Add support for GIT branch specific remote paths

### DIFF
--- a/lib/synchrotron.rb
+++ b/lib/synchrotron.rb
@@ -97,10 +97,10 @@ module Synchrotron; class << self
     rsync_options = @config[:rsync_options].join(' ')
     rsync_remote  = escape_arg(File.join(@config[:remote_path], relative_path(path)))
 
-    if /GIT_BRANCH/.match(rsync_remote)
-      git_branch = `git symbolic-ref HEAD`[/\/([^\/]*)$/,1].chomp
-      @log.debug "git branch is '#{git_branch}'."
-      rsync_remote.gsub!(/GIT_BRANCH/,git_branch)
+    if rsync_remote.include?('GIT_BRANCH')
+      git_branch = `git symbolic-ref HEAD`[/([^\/])*$/].chomp
+      @log.info "git branch is '#{git_branch}'."
+      rsync_remote.gsub!('GIT_BRANCH',git_branch)
     end
 
     # Build exclusion list.


### PR DESCRIPTION
This change adds handling for the magic path element GIT_BRANCH to the remote path. It will be re-evaluated with each sync operation. Meaning if you change branches while synchrotron is running, it will sync the NEW branch to it's own dir on the server, and not crush the one you had previously been syncing.
